### PR TITLE
Add a hefty notebook image option

### DIFF
--- a/azure-pangeo/values.yaml
+++ b/azure-pangeo/values.yaml
@@ -39,7 +39,9 @@ pangeo:
               'display_name': 'Panzure notebook (hefty)',
               'kubespawner_override': {
                 'singleuser_image_spec': 'informaticslab/panzure-shared-env-notebook:0.0.14',
+                'cpu_guarantee': 7,
                 'cpu_limit': 14,
+                'mem_guarantee': '12G',
                 'mem_limit': '54G',
                 },
             }]

--- a/azure-pangeo/values.yaml
+++ b/azure-pangeo/values.yaml
@@ -29,6 +29,21 @@ pangeo:
           c.JupyterHub.template_paths = ['/usr/local/share/jupyterhub/custom_templates/',
                                         '/usr/local/share/jupyterhub/templates/']
 
+          c.KubeSpawner.profile_list = [
+            {
+              'display_name': 'Panzure notebook (standard)',
+              'kubespawner_override': {'singleuser_image_spec': 'informaticslab/panzure-shared-env-notebook:0.0.14'},
+              'default': True
+            },
+            {
+              'display_name': 'Panzure notebook (hefty)',
+              'kubespawner_override': {
+                'singleuser_image_spec': 'informaticslab/panzure-shared-env-notebook:0.0.14',
+                'cpu_limit': 14,
+                'mem_limit': '54G',
+                },
+            }]
+
       cookieSecret: OVERRIDEME
       resources:
         requests:


### PR DESCRIPTION
Add a launcher option to the hub for launching a single-user image that can request much more compute resource, specifically:

* 7 - 14 CPUs
* 12 - 54 GB RAM